### PR TITLE
dev: Improve VM type

### DIFF
--- a/src/smockit/binding.ts
+++ b/src/smockit/binding.ts
@@ -3,8 +3,8 @@ import { TransactionExecutionError } from 'hardhat/internal/hardhat-network/prov
 import { HardhatNetworkProvider } from 'hardhat/internal/hardhat-network/provider/provider'
 
 /* Imports: Internal */
-import { MockContract, VmError } from './types'
-import { toHexString } from '../utils'
+import { MockContract, SmockedVM, VmError } from './types'
+import { fromHexString, toHexString } from '../utils'
 
 /**
  * Checks to see if smock has been initialized already. Basically just checking to see if we've
@@ -27,7 +27,7 @@ const initializeSmock = (provider: HardhatNetworkProvider): void => {
 
   // Will need to reference these things.
   const node = (provider as any)._node
-  const vm = node._vm
+  const vm: SmockedVM = node._vm
 
   // Attach some extra state to the VM.
   vm._smockState = {
@@ -142,7 +142,7 @@ export const bindSmock = async (
     initializeSmock(provider)
   }
 
-  const vm = (provider as any)._node._vm
+  const vm: SmockedVM = (provider as any)._node._vm
   const pStateManager = vm.pStateManager
 
   // Add mock to our list of mocks currently attached to the VM.
@@ -152,7 +152,7 @@ export const bindSmock = async (
   // Solidity will sometimes throw if it's calling something without code (I forget the exact
   // scenario that causes this throw).
   await pStateManager.putContractCode(
-    mock.address.toLowerCase(),
+    fromHexString(mock.address),
     Buffer.from('00', 'hex')
   )
 }

--- a/src/smockit/smockit.ts
+++ b/src/smockit/smockit.ts
@@ -1,6 +1,6 @@
 /* Imports: External */
 import hre from 'hardhat'
-import { Contract, ContractFactory, ContractFunction, ethers } from 'ethers'
+import { Contract, ContractFactory, ethers } from 'ethers'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import { HardhatNetworkProvider } from 'hardhat/internal/hardhat-network/provider/provider'
 
@@ -9,6 +9,7 @@ import {
   MockContract,
   MockContractFunction,
   MockReturnValue,
+  SmockedVM,
   SmockOptions,
   SmockSpec,
 } from './types'
@@ -88,7 +89,7 @@ const makeContractInterfaceFromSpec = (
 const smockifyFunction = (
   contract: Contract,
   functionName: string,
-  vm: any
+  vm: SmockedVM
 ): MockContractFunction => {
   return {
     get calls() {

--- a/src/smockit/types.ts
+++ b/src/smockit/types.ts
@@ -52,3 +52,21 @@ export class VmError {
     this.errorType = 'VmError'
   }
 }
+
+export interface SmockedVM {
+  _smockState: {
+    mocks: {
+      [address: string]: MockContract
+    }
+    calls: {
+      [address: string]: any[]
+    }
+    messages: any[]
+  }
+
+  on: (event: string, callback: Function) => void
+
+  pStateManager: {
+    putContractCode: (address: Buffer, code: Buffer) => Promise<void>
+  }
+}


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Was using `any` as a type for the ethereumjs-vm. Kinda bad. Replaced with a more explicit type.
