### PR TITLE
Correctly make assertions about storage slots

### DIFF
--- a/src/smoddit/smoddit.ts
+++ b/src/smoddit/smoddit.ts
@@ -69,16 +69,20 @@ export const smoddit = async (
       }
 
       const slots = getStorageSlots(layout, storage)
-      return slots.every(async (slot) => {
-        return (
+      for (const slot of slots) {
+        if (
           toHexString32(
             await pStateManager.getContractStorage(
               fromHexString(contract.address),
               fromHexString(slot.hash.toLowerCase())
             )
-          ) === slot.value
-        )
-      })
+          ) !== slot.value
+        ) {
+          return false
+        }
+      }
+
+      return true
     }
 
     contract.smodify = {


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The `.every` here was... completely broken. It doesn't work like this at all. Whoops! This will now correctly check storage slots. We didn't catch this because it seems like no one was really using the feature.
