### PR TITLE
fix: Make smoddit work for bytesN map keys

### DIFF
--- a/src/utils/hex-utils.ts
+++ b/src/utils/hex-utils.ts
@@ -6,10 +6,15 @@ export const toHexString32 = (
   value: string | number | BigNumber | boolean
 ): string => {
   if (typeof value === 'string' && value.startsWith('0x')) {
-    return '0x' + remove0x(value).padStart(64, '0').toLowerCase()
+    return '0x' + remove0x(value).padEnd(64, '0').toLowerCase()
   } else if (typeof value === 'boolean') {
-    return toHexString32(value ? 1 : 0)
+    return '0x' + `${value ? 1 : 0}`.padStart(64, '0')
   } else {
-    return toHexString32(BigNumber.from(value).toHexString())
+    return (
+      '0x' +
+      remove0x(BigNumber.from(value).toHexString())
+        .padStart(64, '0')
+        .toLowerCase()
+    )
   }
 }

--- a/test/contracts/SimpleStorageGetter.sol
+++ b/test/contracts/SimpleStorageGetter.sol
@@ -15,6 +15,9 @@ contract SimpleStorageGetter {
     mapping (uint256 => uint256) _uint256Map;
     mapping (uint256 => mapping (uint256 => uint256)) _uint256NestedMap;
 
+    // specific stuff for regressions
+    mapping (bytes5 => bool) _bytes5ToBoolMap;
+
     constructor(
         uint256 _inA
     ) {
@@ -92,5 +95,17 @@ contract SimpleStorageGetter {
         )
     {
         return _uint256NestedMap[_keyA][_keyB];
+    }
+
+    function getBytes5ToBoolMapValue(
+        bytes5 _key
+    )
+        public
+        view
+        returns (
+            bool _out
+        )
+    {
+        return _bytes5ToBoolMap[_key];
     }
 }

--- a/test/smoddit/smoddit.spec.ts
+++ b/test/smoddit/smoddit.spec.ts
@@ -110,6 +110,19 @@ describe('smoddit', () => {
 
         expect(await smod.getConstructorUint256()).to.equal(1234)
       })
+
+      it('should be able to set values in a bytes 5 => bool mapping', async () => {
+        const key = '0x0000005678'
+        const val = true
+
+        smod.smodify.put({
+          _bytes5ToBoolMap: {
+            [key]: val,
+          },
+        })
+
+        expect(await smod.getBytes5ToBoolMapValue(key)).to.equal(val)
+      })
     })
   })
 })


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes `smoddit` so that it'll work for `bytesN` keys. Underlying bug was that all values were being treated like `uint` and were being right-aligned (padding the start with zeros). Solidity handles `bytesN` where `N < 32` by padding the *end* with zeros (left-aligned). Also adds a regression test.

**Metadata**
- Fixes #35 
