### PR TITLE
fix: Smodify addresses correctly

### DIFF
--- a/src/utils/hex-utils.ts
+++ b/src/utils/hex-utils.ts
@@ -6,7 +6,15 @@ export const toHexString32 = (
   value: string | number | BigNumber | boolean
 ): string => {
   if (typeof value === 'string' && value.startsWith('0x')) {
-    return '0x' + remove0x(value).padEnd(64, '0').toLowerCase()
+    // Known bug here is that bytes20 and address are indistinguishable but have to be treated
+    // differently. Address gets padded on the right, bytes20 gets padded on the left. Address is
+    // way more common so I'm going with the strategy of treating all bytes20 like addresses.
+    // Sorry to anyone who wants to smodify bytes20 values :-/ requires a bit of rewrite to fix.
+    if (value.length === 42) {
+      return '0x' + remove0x(value).padStart(64, '0').toLowerCase()
+    } else {
+      return '0x' + remove0x(value).padEnd(64, '0').toLowerCase()
+    }
   } else if (typeof value === 'boolean') {
     return '0x' + `${value ? 1 : 0}`.padStart(64, '0')
   } else {

--- a/test/contracts/SimpleStorageGetter.sol
+++ b/test/contracts/SimpleStorageGetter.sol
@@ -8,15 +8,20 @@ contract SimpleStorageGetter {
         bool valueB;
     }
 
+    address internal _address;
     uint256 internal _constructorUint256;
     uint256 internal _uint256;
     bool internal _bool;
     SimpleStruct internal _SimpleStruct;
     mapping (uint256 => uint256) _uint256Map;
     mapping (uint256 => mapping (uint256 => uint256)) _uint256NestedMap;
-
-    // specific stuff for regressions
     mapping (bytes5 => bool) _bytes5ToBoolMap;
+    mapping (address => bool) _addressToBoolMap;
+    mapping (address => address) _addressToAddressMap;
+
+    // Testing storage slot packing.
+    bool internal _packedA;
+    address internal _packedB;
 
     constructor(
         uint256 _inA
@@ -60,6 +65,16 @@ contract SimpleStorageGetter {
         )
     {
         return _bool;
+    }
+
+    function getAddress()
+        public
+        view
+        returns (
+            address _out
+        )
+    {
+        return _address;
     }
 
     function getSimpleStruct()
@@ -107,5 +122,39 @@ contract SimpleStorageGetter {
         )
     {
         return _bytes5ToBoolMap[_key];
+    }
+
+    function getAddressToBoolMapValue(
+        address _key
+    )
+        public
+        view
+        returns (
+            bool _out
+        )
+    {
+        return _addressToBoolMap[_key];
+    }
+
+    function getAddressToAddressMapValue(
+        address _key
+    )
+        public
+        view
+        returns (
+            address _out
+        )
+    {
+        return _addressToAddressMap[_key];
+    }
+
+    function getPackedAddress()
+        public
+        view
+        returns (
+            address
+        )
+    {
+        return _packedB;
     }
 }

--- a/test/smoddit/smoddit.spec.ts
+++ b/test/smoddit/smoddit.spec.ts
@@ -26,7 +26,7 @@ describe('smoddit', () => {
       it('should be able to return a uint256', async () => {
         const ret = 1234
 
-        smod.smodify.put({
+        await smod.smodify.put({
           _uint256: ret,
         })
 
@@ -36,11 +36,32 @@ describe('smoddit', () => {
       it('should be able to return a boolean', async () => {
         const ret = true
 
-        smod.smodify.put({
+        await smod.smodify.put({
           _bool: ret,
         })
 
         expect(await smod.getBool()).to.equal(ret)
+      })
+
+      it('should be able to return an address', async () => {
+        const ret = '0x558ba9b8d78713fbf768c1f8a584485B4003f43F'
+
+        await smod.smodify.put({
+          _address: ret,
+        })
+
+        expect(await smod.getAddress()).to.equal(ret)
+      })
+
+      // TODO: Need to solve this with a rewrite.
+      it.skip('should be able to return an address in a packed storage slot', async () => {
+        const ret = '0x558ba9b8d78713fbf768c1f8a584485B4003f43F'
+
+        await smod.smodify.put({
+          _packedB: ret,
+        })
+
+        expect(await smod.getPackedAddress()).to.equal(ret)
       })
 
       it('should be able to return a simple struct', async () => {
@@ -49,7 +70,7 @@ describe('smoddit', () => {
           valueB: true,
         }
 
-        smod.smodify.put({
+        await smod.smodify.put({
           _SimpleStruct: ret,
         })
 
@@ -62,7 +83,7 @@ describe('smoddit', () => {
         const retKey = 1234
         const retVal = 5678
 
-        smod.smodify.put({
+        await smod.smodify.put({
           _uint256Map: {
             [retKey]: retVal,
           },
@@ -76,7 +97,7 @@ describe('smoddit', () => {
         const retKeyB = 4321
         const retVal = 5678
 
-        smod.smodify.put({
+        await smod.smodify.put({
           _uint256NestedMap: {
             [retKeyA]: {
               [retKeyB]: retVal,
@@ -92,7 +113,7 @@ describe('smoddit', () => {
       it('should not return the set value if the value has been changed by the contract', async () => {
         const ret = 1234
 
-        smod.smodify.put({
+        await smod.smodify.put({
           _uint256: ret,
         })
 
@@ -104,24 +125,50 @@ describe('smoddit', () => {
       it('should return the set value if it was set in the constructor', async () => {
         const ret = 1234
 
-        smod.smodify.put({
+        await smod.smodify.put({
           _constructorUint256: ret,
         })
 
         expect(await smod.getConstructorUint256()).to.equal(1234)
       })
 
-      it('should be able to set values in a bytes 5 => bool mapping', async () => {
+      it('should be able to set values in a bytes5 => bool mapping', async () => {
         const key = '0x0000005678'
         const val = true
 
-        smod.smodify.put({
+        await smod.smodify.put({
           _bytes5ToBoolMap: {
             [key]: val,
           },
         })
 
         expect(await smod.getBytes5ToBoolMapValue(key)).to.equal(val)
+      })
+
+      it('should be able to set values in a address => bool mapping', async () => {
+        const key = '0x558ba9b8d78713fbf768c1f8a584485B4003f43F'
+        const val = true
+
+        await smod.smodify.put({
+          _addressToBoolMap: {
+            [key]: val,
+          },
+        })
+
+        expect(await smod.getAddressToBoolMapValue(key)).to.equal(val)
+      })
+
+      it('should be able to set values in a address => address mapping', async () => {
+        const key = '0x558ba9b8d78713fbf768c1f8a584485B4003f43F'
+        const val = '0x063bE0Af9711a170BE4b07028b320C90705fec7C'
+
+        await smod.smodify.put({
+          _addressToAddressMap: {
+            [key]: val,
+          },
+        })
+
+        expect(await smod.getAddressToAddressMapValue(key)).to.equal(val)
       })
     })
   })


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug that prevented addresses from being modified correctly + adds tests to cover regressions. Also adds a test for a case that we realized is broken (packed storage slot values) but we'll need a bit of a rewrite to fix this.
