### PR TITLE
fix: don't throw an error when a smocked fn has no calls

### DIFF
--- a/src/smockit/smockit.ts
+++ b/src/smockit/smockit.ts
@@ -63,7 +63,7 @@ const smockifyFunction = (
       return
     },
     get calls() {
-      return vm._smockState.calls[contract.address.toLowerCase()]
+      return (vm._smockState.calls[contract.address.toLowerCase()] || [])
         .map((calldataBuf: Buffer) => {
           const sighash = toHexString(calldataBuf.slice(0, 4))
           const fragment = contract.interface.getFunction(sighash)


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Minor tweak to fix an error that causes smock to complain if you try to access calls for a function that hasn't been called yet.

**Metadata**
- Fixes #42 
